### PR TITLE
Support dependencySet of Spring Dependency management plugin

### DIFF
--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -23,6 +23,10 @@ class DependencyUpdate {
         "(group[ \\t]*:[ \\t]*[\"']" + this.group + "[\"'][ \\t]*,[ \\t]*name[ \\t]*:[ \\t]*[\"']" + this.name +
                 "[\"'][ \\t]*,[ \\t]*version[ \\t]*:[ \\t]*[\"']).*?([\"'])"
     }
+    String oldModuleVersionDependencySetString() {
+        "(dependencySet\\s*\\(\\s*group\\s*:\\s*[\"']" + this.group +
+                "[\"']\\s*,\\s*version\\s*:\\s*[\"'])[^\\s\"']+?([\"'][\\s)]\\s*\\{[^}]*entry\\s*[\"']" + this.name + "[\"'])"
+    }
     String oldPluginVersionMatchString() {
         "(id[ \\t\\(]+[\"']" + this.group + "[\"'][ \\t\\)]+version[ \\t]+[\"'])" + this.oldVersion + "([\"'])"
     }

--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -41,6 +41,10 @@ class DependencyUpdate {
         "group[ \\t]*:[ \\t]*[\"']" + this.group + "[\"'][ \\t]*,[ \\t]*name[ \\t]*:[ \\t]*[\"']" + this.name +
                 "[\"'][ \\t]*,[ \\t]*version[ \\t]*:[ \\t]*([^\\s\"']+?)[\\s)]"
     }
+    String variableInDependencySetString() {
+        "dependencySet\\s*\\(\\s*group\\s*:\\s*[\"']" + this.group +
+                "[\"']\\s*,\\s*version\\s*:\\s*([^\\s\"']+?)[\\s)]\\s*\\{[^}]*entry\\s*[\"']" + this.name + "[\"']"
+    }
     String toString() {
         "${this.group}:${this.name} [${this.oldVersion} -> ${this.newVersion}]"
     }

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -78,6 +78,11 @@ class UseLatestVersionsTask extends DefaultTask {
                 gradleFileContents[dotGradleFileName] =
                         gradleFileContents[dotGradleFileName].replaceAll(
                                 update.oldModuleVersionMapFormatMatchString(), update.newVersionString())
+
+                // dependencySet notation
+                gradleFileContents[dotGradleFileName] =
+                        gradleFileContents[dotGradleFileName].replaceAll(
+                                update.oldModuleVersionDependencySetString(), update.newVersionString())
             }
         }
     }

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -115,6 +115,11 @@ class UseLatestVersionsTask extends DefaultTask {
                 variableMatch = gradleFileContents[dotGradleFileName] =~
                         update.variableUseMapFormatMatchString()
                 getVariablesFromMatches(variableMatch, versionVariables, update, problemVariables)
+
+                // Variable in dependencySet format
+                variableMatch = gradleFileContents[dotGradleFileName] =~
+                        update.variableInDependencySetString()
+                getVariablesFromMatches(variableMatch, versionVariables, update, problemVariables)
             }
         }
 

--- a/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
@@ -172,4 +172,44 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedBuildFile.contains('junit:junit:4.12')
         updatedSecondFile.contains("log4j:log4j:$CurrentVersions.LOG4J")
     }
+
+
+    void "spring gradle dependency management plugin annotation with variable"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+                id "io.spring.dependency-management" version "1.0.6.RELEASE"
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencyManagement {
+                dependencies {
+                    dependency "junit:junit:4.0"
+                    dependencySet(group: 'log4j', version: "1.2.16") {
+                        entry 'log4j'
+                    }
+                }
+            }
+            
+            dependencies {
+                testCompile "junit:junit"
+                compile "log4j:log4j"
+            }
+        """
+
+        when:
+        useLatestVersions()
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains("dependency \"junit:junit:$CurrentVersions.JUNIT\"")
+        updatedBuildFile.contains("dependencySet(group: 'log4j', version: \"$CurrentVersions.LOG4J\")")
+    }
 }

--- a/src/test/groovy/se/patrikerdes/VariableUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/VariableUpdatesFunctionalTest.groovy
@@ -366,4 +366,55 @@ class VariableUpdatesFunctionalTest extends BaseFunctionalTest {
         !updatedSecondFile.contains("junit_version = '$CurrentVersions.JUNIT'")
         result.output.contains('A problem was detected')
     }
+
+    void "spring gradle dependency management plugin annotation"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+                id "io.spring.dependency-management" version "1.0.6.RELEASE"
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            def junit_version = '4.0'
+            def log4j_version = '1.2.16'
+            
+            dependencyManagement {
+                dependencies {
+                    dependency "junit:junit:\$junit_version"
+                    dependencySet(group: 'log4j', version: log4j_version) {
+                        entry 'log4j'
+                    }
+                }
+            }
+            
+            dependencies {
+                testCompile "junit:junit"
+                compile "log4j:log4j"
+            }
+        """
+
+        when:
+        useLatestVersions()
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains("def junit_version = '$CurrentVersions.JUNIT'")
+        updatedBuildFile.contains("def log4j_version = '$CurrentVersions.LOG4J'")
+        updatedBuildFile.contains("""
+            dependencyManagement {
+                dependencies {
+                    dependency "junit:junit:\$junit_version"
+                    dependencySet(group: 'log4j', version: log4j_version) {
+                        entry 'log4j'
+                    }
+                }
+            }""")
+    }
 }


### PR DESCRIPTION
With this change also dependencySet notations of the [Spring Dependency management plugin](https://github.com/spring-gradle-plugins/dependency-management-plugin) is supported.

Example:
```
dependencyManagement {
    dependencies {
        dependencySet(group: 'org.hibernate', version: hibernateValidatorVersion) {
            entry 'hibernate-validator'
            entry 'hibernate-core'
        }
    }
}
```