### PR TITLE
Make it possible to let the user configure the outputFormatter.

### DIFF
--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsPlugin.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsPlugin.groovy
@@ -7,7 +7,6 @@ import org.gradle.api.Plugin
 @CompileStatic
 class UseLatestVersionsPlugin implements Plugin<Project> {
     void apply(Project project) {
-        System.setProperty('outputFormatter', 'json,xml,plain')
         project.task('useLatestVersions', type: UseLatestVersionsTask, dependsOn: 'dependencyUpdates')
         project.task('useLatestVersionsCheck', type: UseLatestVersionsCheckTask, dependsOn: 'dependencyUpdates')
     }


### PR DESCRIPTION
This fixes issue #16.

The gradle-versions-plugin has a default outputFormatter of 'plain'
when not configured. You can override this by setting the task property
`outputFormatter` in your build.gradle:
https://github.com/ben-manes/gradle-versions-plugin#report-format

Before this change, it wasn't possible to create a custom report format.
By removing the hardcoded System-property `outputFormatter`, it becomes
configurable again and creating custom reports is possible again.

The last commit 45e15dc949184d023ec5fd39faa80da8220cd65b fixed issue #3,
but the current version of gradle-versions-plugin should produce a
plaintext report by default (also fixing the issue), so removing this
System-property shouldn't introduce regression.