### PR TITLE
Kotlin dsl separate named and unnamed group name and version

### DIFF
--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -31,6 +31,16 @@ class DependencyUpdate {
     String oldPluginVersionMatchString() {
         "(id[ \\t\\(]+[\"']" + this.group + "[\"'][ \\t\\)]+version[ \\t]+[\"'])" + this.oldVersion + "([\"'])"
     }
+    String oldModuleVersionKotlinUnnamedParametersMatchString() {
+        '((?:testRuntimeOnly|implementation|annotationProcessor|api|apiDependenciesMetadata|apiElements|compile|' +
+                'compileClasspath|compileOnly|compileOnlyDependenciesMetadata|implementation|' +
+                'implementationDependenciesMetadata|runtime|runtimeClasspath|runtimeElements|runtimeOnly|' +
+                'runtimeOnlyDependenciesMetadata|testAnnotationProcessor|testApi|testApiDependenciesMetadata|' +
+                'testCompile|testCompileClasspath|testCompileOnly|testCompileOnlyDependenciesMetadata|' +
+                'testImplementation|testImplementationDependenciesMetadata|testKotlinScriptDef|' +
+                'testKotlinScriptDefExtensions|testRuntime|testRuntimeClasspath|testRuntimeOnlyDependenciesMetadata)' +
+                "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*\")${this.oldVersion}*(\"\\s*\\))"
+    }
     String newVersionString() {
         '$1' + this.newVersion + '$2'
     }

--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -41,25 +41,23 @@ class DependencyUpdate {
                 'testKotlinScriptDefExtensions|testRuntime|testRuntimeClasspath|testRuntimeOnlyDependenciesMetadata)' +
                 "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*\")${this.oldVersion}(\"\\s*\\))"
     }
+    String parameterName = '\\w*'
+    String parameterValueWithQuotes = '\"[^\"]*\"'
+    String parameterValueWithoutQuotes = '[^\"\\s,]+'
+    String parameterValue = "(?:$parameterValueWithQuotes|$parameterValueWithoutQuotes)"
+    String additionalParameter = "(?:\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
+    String groupParameter = "group\\s*=\\s*\"$group\"\\s*,?\\s*"
+    String nameParameter = "name\\s*=\\s*\"$name\"\\s*,?\\s*"
     List<String> oldModuleVersionKotlinSeparateNamedParametersMatchString() {
-        String parameterName = '\\w*'
-        String parameterValueWithQuotes = '\"[^\"]*\"'
-        String parameterValueWithoutQuotes = '[^\"\\s]+'
-        String parameterValue = "(?:$parameterValueWithQuotes|$parameterValueWithoutQuotes)"
         String versionParameterValue = '\")[^\"]*(\"'
-        String additionalParameter = "(?:\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
         String versionParameter = "version\\s*=\\s*$versionParameterValue\\s*,?\\s*"
-        String parameterAppendix = "\\s*=\\s*$parameterValue\\s*,?\\s*"
-        String groupParameter = "group$parameterAppendix"
-        String nameParameter = "name$parameterAppendix"
 
         Closure<String> createPermutation = { String permutation ->
-            return "(\\(" +
-                    "\\s*$additionalParameter*" +
-                    // Permutations
-                    permutation +
-                    "$additionalParameter*" +
-                    "\\))"
+            '(\\(' +
+                "\\s*$additionalParameter*" +
+                permutation +
+                "$additionalParameter*" +
+            '\\))'
         }
 
         List<GString> permutations = [
@@ -68,7 +66,7 @@ class DependencyUpdate {
                 "$nameParameter$groupParameter$versionParameter",
                 "$nameParameter$versionParameter$groupParameter",
                 "$versionParameter$groupParameter$nameParameter",
-                "$versionParameter$nameParameter$groupParameter"
+                "$versionParameter$nameParameter$groupParameter",
         ]
         permutations.collect {
             createPermutation(it)
@@ -102,6 +100,30 @@ class DependencyUpdate {
                 'testImplementation|testImplementationDependenciesMetadata|testKotlinScriptDef|' +
                 'testKotlinScriptDefExtensions|testRuntime|testRuntimeClasspath|testRuntimeOnlyDependenciesMetadata)' +
                 "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*([^\\s\"']+)\\s*\\)"
+    }
+    List<String> variableKotlinSeparateNamedParametersMatchString() {
+        String versionParameterValue = "($parameterValueWithoutQuotes)"
+        String versionParameter = "version\\s*=\\s*$versionParameterValue\\s*,?\\s*"
+
+        Closure<String> createPermutation = { String permutation ->
+            '\\(' +
+                "\\s*$additionalParameter*" +
+                permutation +
+                "$additionalParameter*" +
+            '\\)'
+        }
+
+        List<GString> permutations = [
+                "$groupParameter$nameParameter$versionParameter",
+                "$groupParameter$versionParameter$nameParameter",
+                "$nameParameter$groupParameter$versionParameter",
+                "$nameParameter$versionParameter$groupParameter",
+                "$versionParameter$groupParameter$nameParameter",
+                "$versionParameter$nameParameter$groupParameter",
+        ]
+        permutations.collect {
+            createPermutation(it)
+        }
     }
     String toString() {
         "${this.group}:${this.name} [${this.oldVersion} -> ${this.newVersion}]"

--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -39,7 +39,7 @@ class DependencyUpdate {
                 'testCompile|testCompileClasspath|testCompileOnly|testCompileOnlyDependenciesMetadata|' +
                 'testImplementation|testImplementationDependenciesMetadata|testKotlinScriptDef|' +
                 'testKotlinScriptDefExtensions|testRuntime|testRuntimeClasspath|testRuntimeOnlyDependenciesMetadata)' +
-                "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*\")${this.oldVersion}*(\"\\s*\\))"
+                "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*\")${this.oldVersion}(\"\\s*\\))"
     }
     String newVersionString() {
         '$1' + this.newVersion + '$2'
@@ -59,6 +59,16 @@ class DependencyUpdate {
     String variableInDependencySetString() {
         "dependencySet\\s*\\(\\s*group\\s*:\\s*[\"']" + this.group +
                 "[\"']\\s*,\\s*version\\s*:\\s*([^\\s\"']+?)[\\s)]\\s*\\{[^}]*entry\\s*[\"']" + this.name + "[\"']"
+    }
+    String variableKotlinUnnamedParametersMatchString() {
+        '(?:testRuntimeOnly|implementation|annotationProcessor|api|apiDependenciesMetadata|apiElements|compile|' +
+                'compileClasspath|compileOnly|compileOnlyDependenciesMetadata|implementation|' +
+                'implementationDependenciesMetadata|runtime|runtimeClasspath|runtimeElements|runtimeOnly|' +
+                'runtimeOnlyDependenciesMetadata|testAnnotationProcessor|testApi|testApiDependenciesMetadata|' +
+                'testCompile|testCompileClasspath|testCompileOnly|testCompileOnlyDependenciesMetadata|' +
+                'testImplementation|testImplementationDependenciesMetadata|testKotlinScriptDef|' +
+                'testKotlinScriptDefExtensions|testRuntime|testRuntimeClasspath|testRuntimeOnlyDependenciesMetadata)' +
+                "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*([^\\s\"']+)\\s*\\)"
     }
     String toString() {
         "${this.group}:${this.name} [${this.oldVersion} -> ${this.newVersion}]"

--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -41,6 +41,39 @@ class DependencyUpdate {
                 'testKotlinScriptDefExtensions|testRuntime|testRuntimeClasspath|testRuntimeOnlyDependenciesMetadata)' +
                 "\\s*\\(\\s*\"${this.group}\"\\s*,\\s*\"${this.name}\"\\s*,\\s*\")${this.oldVersion}(\"\\s*\\))"
     }
+    List<String> oldModuleVersionKotlinSeparateNamedParametersMatchString() {
+        String parameterName = '\\w*'
+        String parameterValueWithQuotes = '\"[^\"]*\"'
+        String parameterValueWithoutQuotes = '[^\"\\s]+'
+        String parameterValue = "(?:$parameterValueWithQuotes|$parameterValueWithoutQuotes)"
+        String versionParameterValue = '\")[^\"]*(\"'
+        String additionalParameter = "(?:\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
+        String versionParameter = "version\\s*=\\s*$versionParameterValue\\s*,?\\s*"
+        String parameterAppendix = "\\s*=\\s*$parameterValue\\s*,?\\s*"
+        String groupParameter = "group$parameterAppendix"
+        String nameParameter = "name$parameterAppendix"
+
+        Closure<String> createPermutation = { String permutation ->
+            return "(\\(" +
+                    "\\s*$additionalParameter*" +
+                    // Permutations
+                    permutation +
+                    "$additionalParameter*" +
+                    "\\))"
+        }
+
+        List<GString> permutations = [
+                "$groupParameter$nameParameter$versionParameter",
+                "$groupParameter$versionParameter$nameParameter",
+                "$nameParameter$groupParameter$versionParameter",
+                "$nameParameter$versionParameter$groupParameter",
+                "$versionParameter$groupParameter$nameParameter",
+                "$versionParameter$nameParameter$groupParameter"
+        ]
+        permutations.collect {
+            createPermutation(it)
+        }
+    }
     String newVersionString() {
         '$1' + this.newVersion + '$2'
     }

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -131,6 +131,11 @@ class UseLatestVersionsTask extends DefaultTask {
                 variableMatch = gradleFileContents[dotGradleFileName] =~
                         update.variableInDependencySetString()
                 getVariablesFromMatches(variableMatch, versionVariables, update, problemVariables)
+
+                // Variable in Kotlin notation
+                variableMatch = gradleFileContents[dotGradleFileName] =~
+                        update.variableKotlinUnnamedParametersMatchString()
+                getVariablesFromMatches(variableMatch, versionVariables, update, problemVariables)
             }
         }
 

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -85,10 +85,17 @@ class UseLatestVersionsTask extends DefaultTask {
                         gradleFileContents[dotGradleFileName].replaceAll(
                                 update.oldModuleVersionDependencySetString(), update.newVersionString())
 
-                // Kotlin notation
+                // Kotlin unnamed notation
                 gradleFileContents[dotGradleFileName] =
                         gradleFileContents[dotGradleFileName].replaceAll(
                                 update.oldModuleVersionKotlinUnnamedParametersMatchString(), update.newVersionString())
+
+                // Kotlin named notation
+                update.oldModuleVersionKotlinSeparateNamedParametersMatchString().forEach { String it ->
+                    gradleFileContents[dotGradleFileName] =
+                            gradleFileContents[dotGradleFileName].replaceAll(
+                                    it, update.newVersionString())
+                }
             }
         }
     }

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -84,6 +84,11 @@ class UseLatestVersionsTask extends DefaultTask {
                 gradleFileContents[dotGradleFileName] =
                         gradleFileContents[dotGradleFileName].replaceAll(
                                 update.oldModuleVersionDependencySetString(), update.newVersionString())
+
+                // Kotlin notation
+                gradleFileContents[dotGradleFileName] =
+                        gradleFileContents[dotGradleFileName].replaceAll(
+                                update.oldModuleVersionKotlinUnnamedParametersMatchString(), update.newVersionString())
             }
         }
     }

--- a/src/test/groovy/se/patrikerdes/CommonTest.groovy
+++ b/src/test/groovy/se/patrikerdes/CommonTest.groovy
@@ -1,0 +1,27 @@
+package se.patrikerdes
+
+import static se.patrikerdes.Common.findVariables
+
+import spock.lang.Specification
+
+class CommonTest extends Specification {
+    private final DependencyUpdate update = new DependencyUpdate('junit', 'junit', 'oldVersion', 'newVersion')
+
+    void "ParseVariables"(String fileContent) {
+        expect:
+        String fileName = 'build.gradle.kts'
+        Set problemVariable = []
+
+        List<String> fileNames = [fileName]
+        List<DependencyUpdate> dependencyUpdates = [update]
+        Map<String, String> fileContents = [(fileName): fileContent]
+        Map<String, String> variables = findVariables(fileNames, dependencyUpdates, fileContents, problemVariable)
+
+        fileContent && variables.size() == 1 && variables['junitVersion'] == 'newVersion' && problemVariable.size() == 0
+
+        where:
+        fileContent                                                            | _
+        'testCompile(group = "junit", name = "junit", version = junitVersion)' | _
+        'testCompile("junit", "junit", junitVersion)'                          | _
+    }
+}

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -52,9 +52,9 @@ class DependencyUpdateTest extends Specification {
         expect:
 
         String parameterName = '\\w*'
-        String valueWithQuotes = '\"[^\"]*\"'
-        String valueWithoutQuotes = '[^\"\\s]+'
-        String parameterValue = "(?:$valueWithQuotes|$valueWithoutQuotes)"
+        String parameterValueWithQuotes = '\"[^\"]*\"'
+        String parameterValueWithoutQuotes = '[^\"\\s]+'
+        String parameterValue = "(?:$parameterValueWithQuotes|$parameterValueWithoutQuotes)"
         String additionalParameter = "(?:\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
         String regex =
                 "\\(" +

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -1,0 +1,50 @@
+package se.patrikerdes
+
+import spock.lang.Specification
+
+class DependencyUpdateTest extends Specification {
+    private final DependencyUpdate update = new DependencyUpdate('group', 'name', 'oldVersion', 'newVersion')
+
+    void "oldModuleVersionKotlinSepareteUnnamedParametersMatchString"(String input) {
+        expect:
+        String matchString = update.oldModuleVersionKotlinUnnamedParametersMatchString()
+        String output = input.replaceAll(matchString, update.newVersionString())
+
+        output == input.replace('oldVersion', 'newVersion')
+
+        where:
+        input                                                                       | _
+        '''testRuntimeOnly("group", "name", "oldVersion")'''                        | _
+        '''testRuntimeOnly ( "group" ,"name",     "oldVersion")'''                  | _
+        '''implementation("group", "name", "oldVersion")'''                         | _
+        '''annotationProcessor("group", "name", "oldVersion")'''                    | _
+        '''api("group", "name", "oldVersion")'''                                    | _
+        '''apiDependenciesMetadata("group", "name", "oldVersion")'''                | _
+        '''apiElements("group", "name", "oldVersion")'''                            | _
+        '''compile("group", "name", "oldVersion")'''                                | _
+        '''compileClasspath("group", "name", "oldVersion")'''                       | _
+        '''compileOnly("group", "name", "oldVersion")'''                            | _
+        '''compileOnlyDependenciesMetadata("group", "name", "oldVersion")'''        | _
+        '''implementation("group", "name", "oldVersion")'''                         | _
+        '''implementationDependenciesMetadata("group", "name", "oldVersion")'''     | _
+        '''runtime("group", "name", "oldVersion")'''                                | _
+        '''runtimeClasspath("group", "name", "oldVersion")'''                       | _
+        '''runtimeElements("group", "name", "oldVersion")'''                        | _
+        '''runtimeOnly("group", "name", "oldVersion")'''                            | _
+        '''runtimeOnlyDependenciesMetadata("group", "name", "oldVersion")'''        | _
+        '''testAnnotationProcessor("group", "name", "oldVersion")'''                | _
+        '''testApi("group", "name", "oldVersion")'''                                | _
+        '''testApiDependenciesMetadata("group", "name", "oldVersion")'''            | _
+        '''testCompile("group", "name", "oldVersion")'''                            | _
+        '''testCompileClasspath("group", "name", "oldVersion")'''                   | _
+        '''testCompileOnly("group", "name", "oldVersion")'''                        | _
+        '''testCompileOnlyDependenciesMetadata("group", "name", "oldVersion")'''    | _
+        '''testImplementation("group", "name", "oldVersion")'''                     | _
+        '''testImplementationDependenciesMetadata("group", "name", "oldVersion")''' | _
+        '''testKotlinScriptDef("group", "name", "oldVersion")'''                    | _
+        '''testKotlinScriptDefExtensions("group", "name", "oldVersion")'''          | _
+        '''testRuntime("group", "name", "oldVersion")'''                            | _
+        '''testRuntimeClasspath("group", "name", "oldVersion")'''                   | _
+        '''testRuntimeOnlyDependenciesMetadata("group", "name", "oldVersion")'''    | _
+    }
+}

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -51,7 +51,7 @@ class DependencyUpdateTest extends Specification {
     def "Regex to match Kotlin named parameters"(String input, boolean matches) {
         expect:
 
-        String regex = "\\((\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*)*(?:(group\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|name\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|version\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)?\\s*,?\\s*)(?!.*\\1)){3}(\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?)*\\)"
+        String regex = "\\(\\s*(\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*)*(?:(group\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|name\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|version\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)?\\s*,?\\s*)(?!.*\\1)){3}(\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?)*\\)"
 
         input.matches(regex) == matches
 
@@ -59,6 +59,6 @@ class DependencyUpdateTest extends Specification {
         input                                                                          | matches
         '(group = "group", name = "name", version = "oldVersion")'                     | true
         '(group="group",name="name",version="oldVersion")'                             | true
-//        '(   group    ="group"     ,    name   =  "name" ,version =  "oldVersion"   )' | true
+        '(   group    ="group"     ,    name   =  "name" ,version =  "oldVersion"   )' | true
     }
 }

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -47,4 +47,18 @@ class DependencyUpdateTest extends Specification {
         '''testRuntimeClasspath("group", "name", "oldVersion")'''                   | _
         '''testRuntimeOnlyDependenciesMetadata("group", "name", "oldVersion")'''    | _
     }
+
+    def "Regex to match Kotlin named parameters"(String input, boolean matches) {
+        expect:
+
+        String regex = "\\((\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*)*(?:(group\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|name\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|version\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)?\\s*,?\\s*)(?!.*\\1)){3}(\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?)*\\)"
+
+        input.matches(regex) == matches
+
+        where:
+        input                                                                          | matches
+        '(group = "group", name = "name", version = "oldVersion")'                     | true
+        '(group="group",name="name",version="oldVersion")'                             | true
+//        '(   group    ="group"     ,    name   =  "name" ,version =  "oldVersion"   )' | true
+    }
 }

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -60,9 +60,6 @@ class DependencyUpdateTest extends Specification {
         String parameterAppendix = "\\s*=\\s*$parameterValue\\s*,?\\s*"
         String groupParameter = "group$parameterAppendix"
         String nameParameter = "name$parameterAppendix"
-        String groupAndNameParameter = "(?:" +
-                "(?:$groupParameter|$nameParameter)" +
-                "(?!.*\\1)){2}"
         String regex =
                 "\\(" +
                     "\\s*$additionalParameter*" +

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -95,7 +95,7 @@ class DependencyUpdateTest extends Specification {
         '(name = name, version = oldVersion)'                                          | false
         '(group = group, version = oldVersion)'                                        | false
         '(group = group, name = name)'                                                 | false
-        // Additional parameter (first, last, middle)
+        // Additional parameter
         '(ext = "ext", group = group, name = name, version = oldVersion)'              | true
         // TODO NOT WORKING: Additional parameter in between
         //'(group = group, name = name, ext = "ext", version = oldVersion)'              | true
@@ -112,4 +112,34 @@ class DependencyUpdateTest extends Specification {
         // version parameter is mandatory
         '(group = group, group = name, name = name)'                                   | false
     }
+
+    void "oldModuleVersionKotlinSepareteNamedParametersMatchString"(String input) {
+        expect:
+        String output = ""
+        update.oldModuleVersionKotlinSeparateNamedParametersMatchString().forEach {
+            output = input.replaceAll(it, update.newVersionString())
+            input = output
+        }
+        output == input.replace('oldVersion', 'newVersion')
+
+        where:
+        input                                                                          | _
+        // Allowed whitespaces
+        '(group = "group", name = "name", version = "oldVersion")'                     | _
+        '(group="group",name="name",version="oldVersion")'                             | _
+        '(   group    ="group"     ,    name   =  "name" ,version =  "oldVersion"   )' | _
+        // Variables for group and name instead of string
+        '(group = group, name = name, version = "oldVersion")'                         | _
+        // Additional parameter
+        '(ext = "ext", group = group, name = name, version = "oldVersion")'            | _
+        '(group = group, name = name, version = "oldVersion", ext = "ext")'            | _
+        // Permutations
+        '(group = group, name = name, version = "oldVersion")'                         | _
+        '(group = group, version = "oldVersion", name = name)'                         | _
+        '(name = name, version = "oldVersion", group = group)'                         | _
+        '(name = name, group = group, version = "oldVersion")'                         | _
+        '(version = "oldVersion", name = name, group = group)'                         | _
+        '(version = "oldVersion", group = group, name = name)'                         | _
+    }
+
 }

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -54,14 +54,14 @@ class DependencyUpdateTest extends Specification {
         String parameterName = '\\w*'
         String valueWithQuotes = '\"[^\"]*\"'
         String valueWithoutQuotes = '[^\"\\s]+'
-        String parameterValue = "($valueWithQuotes|$valueWithoutQuotes)"
-        String additionalParameter = "(\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
+        String parameterValue = "(?:$valueWithQuotes|$valueWithoutQuotes)"
+        String additionalParameter = "(?:\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
         String regex =
                 "\\(" +
                     "\\s*$additionalParameter*" +
                         "(?:" +
-                            "(" +
-                                "(group|name)\\s*=\\s*$parameterValue\\s*,?\\s*|" +
+                            "(?:" +
+                                "(?:group|name)\\s*=\\s*$parameterValue\\s*,?\\s*|" +
                                      "version\\s*=\\s*$parameterValue\\s*,?\\s*" +
                             ")" +
                         "(?!.*\\1)){3}" +

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -57,8 +57,32 @@ class DependencyUpdateTest extends Specification {
 
         where:
         input                                                                          | matches
+        // Allowed whitespaces
         '(group = "group", name = "name", version = "oldVersion")'                     | true
         '(group="group",name="name",version="oldVersion")'                             | true
         '(   group    ="group"     ,    name   =  "name" ,version =  "oldVersion"   )' | true
+        // Variables instead of string values
+        '(group = group, name = name, version = oldVersion)'                           | true
+        '(group = "group", name = name, version = "oldVersion")'                       | true
+        // Missing matching quote
+        '(group = "group, name = name, version = oldVersion)'                          | false
+        '(group = group, name = name, version = oldVersion")'                          | false
+        // Parameter name in quotes
+        '("group" = group, name = name, version = oldVersion)'                         | false
+        // Missing parameter
+        '(name = name, version = oldVersion)'                                          | false
+        '(group = group, version = oldVersion)'                                        | false
+        '(group = group, name = name)'                                                 | false
+        // Additional parameter (first, last, middle)
+        '(ext = "ext", group = group, name = name, version = oldVersion)'              | true
+        // NOT POSSIBLE: Additional parameter in between
+        //'(group = group, name = name, ext = "ext", version = oldVersion)'              | true
+        '(group = group, name = name, version = oldVersion, ext = "ext")'              | true
+        // Permutations
+        '(group = group, version = oldVersion, name = name)'                           | true
+        '(version = oldVersion, name = name, group = group)'                           | true
+        '(version = oldVersion, group = group, name = name)'                           | true
+        '(name = name, version = oldVersion, group = group)'                           | true
+        '(name = name, group = group, version = oldVersion)'                           | true
     }
 }

--- a/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
+++ b/src/test/groovy/se/patrikerdes/DependencyUpdateTest.groovy
@@ -51,7 +51,22 @@ class DependencyUpdateTest extends Specification {
     def "Regex to match Kotlin named parameters"(String input, boolean matches) {
         expect:
 
-        String regex = "\\(\\s*(\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*)*(?:(group\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|name\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?\\s*|version\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)?\\s*,?\\s*)(?!.*\\1)){3}(\\s*\\w*\\s*=\\s*(\"[^\"]*\"|[^\"\\s]+)\\s*,?)*\\)"
+        String parameterName = '\\w*'
+        String valueWithQuotes = '\"[^\"]*\"'
+        String valueWithoutQuotes = '[^\"\\s]+'
+        String parameterValue = "($valueWithQuotes|$valueWithoutQuotes)"
+        String additionalParameter = "(\\s*$parameterName\\s*=\\s*$parameterValue\\s*,?\\s*)"
+        String regex =
+                "\\(" +
+                    "\\s*$additionalParameter*" +
+                        "(?:" +
+                            "(" +
+                                "(group|name)\\s*=\\s*$parameterValue\\s*,?\\s*|" +
+                                     "version\\s*=\\s*$parameterValue\\s*,?\\s*" +
+                            ")" +
+                        "(?!.*\\1)){3}" +
+                    "$additionalParameter*" +
+                "\\)"
 
         input.matches(regex) == matches
 
@@ -75,7 +90,7 @@ class DependencyUpdateTest extends Specification {
         '(group = group, name = name)'                                                 | false
         // Additional parameter (first, last, middle)
         '(ext = "ext", group = group, name = name, version = oldVersion)'              | true
-        // NOT POSSIBLE: Additional parameter in between
+        // NOT WORKING: Additional parameter in between
         //'(group = group, name = name, ext = "ext", version = oldVersion)'              | true
         '(group = group, name = name, version = oldVersion, ext = "ext")'              | true
         // Permutations
@@ -84,5 +99,7 @@ class DependencyUpdateTest extends Specification {
         '(version = oldVersion, group = group, name = name)'                           | true
         '(name = name, version = oldVersion, group = group)'                           | true
         '(name = name, group = group, version = oldVersion)'                           | true
+        // NOT WORKING: 2 groups with different values, no name
+        //'(group = group, group = name, version = oldVersion)'                          | false
     }
 }

--- a/src/test/groovy/se/patrikerdes/kotlindsl/KotlinModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/kotlindsl/KotlinModuleUpdatesFunctionalTest.groovy
@@ -190,4 +190,67 @@ class KotlinModuleUpdatesFunctionalTest extends KotlinBaseFunctionalTest {
         then:
         updatedGradlePropertiesFile.contains("junitVersion=$CurrentVersions.JUNIT")
     }
+
+    void "version delegate and separate, named group, name and version parameter can be updated"() {
+        given:
+        buildFile << """
+            plugins {
+                application
+                java
+                id("se.patrikerdes.use-latest-versions")
+                id("com.github.ben-manes.versions") version "$CurrentVersions.VERSIONS"
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            val junitVersion: String by project
+
+            dependencies {
+                testCompile(group = "junit", name = "junit", version = "4.0")
+            }
+        """
+
+        when:
+        useLatestVersions()
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile(group = "junit", name = "junit", version = "' +
+                CurrentVersions.JUNIT + '")')
+    }
+
+    void "version delegate and separate, named group, name and version variable can be updated"() {
+        given:
+        buildFile << """
+            plugins {
+                application
+                java
+                id("se.patrikerdes.use-latest-versions")
+                id("com.github.ben-manes.versions") version "$CurrentVersions.VERSIONS"
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            val junitVersion: String by project
+
+            dependencies {
+                testCompile(group = "junit", name = "junit", version = junitVersion)
+            }
+        """
+        File gradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        gradlePropertiesFile << '''
+            junitVersion=4.0
+        '''
+
+        when:
+        useLatestVersions()
+        String updatedGradlePropertiesFile = gradlePropertiesFile.getText('UTF-8')
+
+        then:
+        updatedGradlePropertiesFile.contains("junitVersion=$CurrentVersions.JUNIT")
+    }
 }

--- a/src/test/groovy/se/patrikerdes/kotlindsl/KotlinModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/kotlindsl/KotlinModuleUpdatesFunctionalTest.groovy
@@ -157,4 +157,37 @@ class KotlinModuleUpdatesFunctionalTest extends KotlinBaseFunctionalTest {
         then:
         updatedBuildFile.contains("""testCompile("junit", "junit", "$CurrentVersions.JUNIT")""")
     }
+
+    void "version delegate and separate, unnamed group, name and version variable can be updated"() {
+        given:
+        buildFile << """
+            plugins {
+                application
+                java
+                id("se.patrikerdes.use-latest-versions")
+                id("com.github.ben-manes.versions") version "$CurrentVersions.VERSIONS"
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            val junitVersion: String by project
+
+            dependencies {
+                testCompile("junit", "junit", junitVersion)
+            }
+        """
+        File gradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        gradlePropertiesFile << '''
+            junitVersion=4.0
+        '''
+
+        when:
+        useLatestVersions()
+        String updatedGradlePropertiesFile = gradlePropertiesFile.getText('UTF-8')
+
+        then:
+        updatedGradlePropertiesFile.contains("junitVersion=$CurrentVersions.JUNIT")
+    }
 }

--- a/src/test/groovy/se/patrikerdes/kotlindsl/KotlinModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/kotlindsl/KotlinModuleUpdatesFunctionalTest.groovy
@@ -128,4 +128,33 @@ class KotlinModuleUpdatesFunctionalTest extends KotlinBaseFunctionalTest {
         updatedKotlinVersionsFile.contains("junit_version = \"$CurrentVersions.JUNIT\"")
         updatedKotlinVersionsFile.contains("log4j_version=\"$CurrentVersions.LOG4J\"")
     }
+
+    void "version delegate and separate, unnamed group, name and version parameter can be updated"() {
+        given:
+        buildFile << """
+            plugins {
+                application
+                java
+                id("se.patrikerdes.use-latest-versions")
+                id("com.github.ben-manes.versions") version "$CurrentVersions.VERSIONS"
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            val junitVersion: String by project
+
+            dependencies {
+                testCompile("junit", "junit", "4.0")
+            }
+        """
+
+        when:
+        useLatestVersions()
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains("""testCompile("junit", "junit", "$CurrentVersions.JUNIT")""")
+    }
 }


### PR DESCRIPTION
Like PR https://github.com/patrikerdes/gradle-use-latest-versions-plugin/pull/19 this PR also fixes issue https://github.com/patrikerdes/gradle-use-latest-versions-plugin/issues/14 but additionally also support named parameters in Gradle Kotlin DSL.

For example following notations are supported now:
```kotlin
            dependencies {
                // unnamed parameters
                testCompile("junit", "junit", "4.0")
                testCompile("junit", "junit", junitVersion)
                // named parameters
                testCompile(group = "junit", name = "junit", version = "4.0")
                testCompile(group = "junit", name = "junit", version = junitVersion)
                // named parameters allow to change the order of the parameters
                testCompile(version = junitVersion, group = "junit", name = "junit")
            }
```

This PR is based on https://github.com/patrikerdes/gradle-use-latest-versions-plugin/pull/19, so it can also be merged afterwards.