### PR TITLE
Changes to address issues with Gradle multi-project builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 group = 'se.patrikerdes'
-version = '0.2.8'
+version = '0.2.9-SNAPSHOT'
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
@@ -17,10 +17,10 @@ class UseLatestVersionsCheckTask extends DefaultTask {
     @TaskAction
     void useLatestVersionsCheckTask() {
         File previousDependencyUpdatesReport =
-                new File(new File(project.rootDir, 'build' + File.separator + 'useLatestVersions'),
+                new File(new File(project.projectDir, 'build' + File.separator + 'useLatestVersions'),
                         'latestDependencyUpdatesReport.json')
         File currentDependencyUpdatesReport =
-                new File(project.rootDir,
+                new File(project.projectDir,
                         'build' + File.separator + 'dependencyUpdates' + File.separator + 'report.json')
 
         if (!previousDependencyUpdatesReport.exists()) {


### PR DESCRIPTION
Hi,

Thanks for providing this very useful plugin. :) This PR contains changes to address issues that were encountered when using the plugin on Gradle multi-project builds. There are two issues that were encountered:

1. The plugin may not make the correct version updates if sub-projects use different Component Selection rules with the Gradle Versions plugin. For example, one sub-project might use a component selection rule to limit updates to a certain dependency, but another project may not impose any rules and uses the latest version of the dependency. In that case the dependency version is unexpectedly updated on the sub-project with the component selection rules because the useLatestVersions task uses the merged dependency updates report created on the root project.
2. If useLatestVersions task is run on a single sub-project (i.e. `gradlew :subproject-a:useLatestVersions`), then the task will fail because Gradle versions plugin won't create the merged report on the root project.

The following changes were made in this PR resolve these issues:

* Updated the tasks to use the dependency update reports generated for the specific project rather than the merged report generated at the root project
* When updating dependency versions, avoid updating build configuration that exists in sub-projects

Unfortunately no unit tests have been provided since it wasn't clear how to make the test cases use multi-project configuration.

Please let me know if there are better ways to address these issues, or if any changes or additional information need to be provided.

Thanks,
Brendan