### PR TITLE
Add flag to update only explicitly listed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ successfully updated.
 will check the *.gradle files as they were when the gradle build started, which means that it can not pick up the
 changes applied by `useLatestVersions`.
 
+## Updating only specific dependencies
+If your Gradle version is 4.6 or higher, you can pass the `--update-dependency` flag to `useLatestVersions` and
+`useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`.  Multiple dependencies can be updated by passing
+the flag multiple times.
+
+```bash
+# gradle useLatestVersions --update-dependency junit:junit --update-dependency com.google.guava:guava && gradle useLatestVersionsCheck --update-dependency junit:junit --update-dependency com.google.guava:guava
+```
+
 ## Supported dependency formats
 
 Dependencies stated in the following formats should cause the version to be successfully updated by the

--- a/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
@@ -24,6 +24,20 @@ class BaseFunctionalTest extends Specification {
                 .build()
     }
 
+    BuildResult useLatestVersionsOnly(String update) {
+        useLatestVersionsOnly([update])
+    }
+
+    BuildResult useLatestVersionsOnly(List<String> updates) {
+        List<String> arguments = ['useLatestVersions']
+        updates.each { arguments << '--update-dependency' << it }
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
+    }
+
     BuildResult useLatestVersions(String gradleVersion) {
         GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -55,6 +69,20 @@ class BaseFunctionalTest extends Specification {
                 .withArguments('useLatestVersionsCheck')
                 .withPluginClasspath()
                 .buildAndFail()
+    }
+
+    BuildResult useLatestVersionsCheckOnly(String update) {
+        useLatestVersionsCheckOnly([update])
+    }
+
+    BuildResult useLatestVersionsCheckOnly(List<String> updates) {
+        List<String> arguments = ['useLatestVersionsCheck']
+        updates.each { arguments << '--update-dependency' << it }
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
     }
 
     BuildResult clean() {

--- a/src/test/groovy/se/patrikerdes/CheckFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/CheckFunctionalTest.groovy
@@ -215,6 +215,38 @@ class CheckFunctionalTest extends BaseFunctionalTest {
         result.output.contains("- log4j:log4j [1.2.16 -> $CurrentVersions.LOG4J]")
     }
 
+    void "useLatestVersionsCheck notes skipped updates due to not being in --update-dependency"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile "log4j:log4j:1.2.16"
+                testCompile "junit:junit:3.0"
+            }
+        """
+
+        when:
+        useLatestVersionsOnly('log4j:log4j')
+        BuildResult result = useLatestVersionsCheckOnly('log4j:log4j')
+
+        then:
+        result.task(':useLatestVersionsCheck').outcome == SUCCESS
+        result.output.contains("""useLatestVersions successfully updated 1 dependency to the latest version:
+ - log4j:log4j [1.2.16 -> $CurrentVersions.LOG4J]""")
+        result.output.contains("""useLatestVersions skipped updating 1 dependency not in --dependency-update:
+ - junit:junit [3.0 -> $CurrentVersions.JUNIT]""")
+    }
+
     void "useLatestVersionsCheck outputs a special message when there was nothing to update"() {
         given:
         buildFile << """

--- a/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
@@ -331,4 +331,33 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedBuildFile.contains("dependency \"junit:junit:$CurrentVersions.JUNIT\"")
         updatedBuildFile.contains("dependencySet(group: 'log4j', version: \"$CurrentVersions.LOG4J\")")
     }
+
+    void "only updates whitelisted dependencies with --update-dependency"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                testCompile "junit:junit:4.0:javadoc@jar"
+                compile "log4j:log4j:1.2.16"
+            }
+        """
+
+        when:
+        useLatestVersionsOnly('log4j:log4j')
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
+    }
 }


### PR DESCRIPTION
In many larger projects, users often want to update only specific dependencies
as updating everything at once may be too large of a change.  Provide such
functionality through a Gradle @Option on the two task classes.

While this @Option API exists only from 4.6 up, this is not a breaking change
for lower versions of Gradle as missing annotation types are simply ignored when
classes are being initialized (JLS §13.5.7).