### PR TITLE
Add flag to ignore specific dependency updates (blacklist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,22 @@ successfully updated.
 will check the *.gradle files as they were when the gradle build started, which means that it can not pick up the
 changes applied by `useLatestVersions`.
 
-## Updating only specific dependencies
+## Updating only specific dependencies (whitelist)
 If your Gradle version is 4.6 or higher, you can pass the `--update-dependency` flag to `useLatestVersions` and
 `useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`.  Multiple dependencies can be updated by passing
 the flag multiple times.
 
 ```bash
 # gradle useLatestVersions --update-dependency junit:junit --update-dependency com.google.guava:guava && gradle useLatestVersionsCheck --update-dependency junit:junit --update-dependency com.google.guava:guava
+```
+
+## Ignore specific dependency updates (blacklist)
+If your Gradle version is 4.6 or higher, you can pass the `--ignore-dependency` flag to `useLatestVersions` and
+`useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`.  Multiple dependencies can be ignored by passing
+the flag multiple times.
+
+```bash
+# gradle useLatestVersions --ignore-dependency junit:junit --ignore-dependency com.google.guava:guava && gradle useLatestVersionsCheck --ignore-dependency junit:junit --ignore-dependency com.google.guava:guava
 ```
 
 ## Supported dependency formats

--- a/README.md
+++ b/README.md
@@ -167,20 +167,20 @@ changes applied by `useLatestVersions`.
 
 ## Updating only specific dependencies (whitelist)
 If your Gradle version is 4.6 or higher, you can pass the `--update-dependency` flag to `useLatestVersions` and
-`useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`.  Multiple dependencies can be updated by passing
-the flag multiple times.
+`useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`.  A complete dependency group can be updated by 
+using the format `$GROUP`. Multiple dependencies can be updated by passing the flag multiple times.
 
 ```bash
-# gradle useLatestVersions --update-dependency junit:junit --update-dependency com.google.guava:guava && gradle useLatestVersionsCheck --update-dependency junit:junit --update-dependency com.google.guava:guava
+# gradle useLatestVersions --update-dependency junit:junit --update-dependency com.google.guava && gradle useLatestVersionsCheck --update-dependency junit:junit --update-dependency com.google.guava
 ```
 
 ## Ignore specific dependency updates (blacklist)
 If your Gradle version is 4.6 or higher, you can pass the `--ignore-dependency` flag to `useLatestVersions` and
-`useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`.  Multiple dependencies can be ignored by passing
-the flag multiple times.
+`useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`. A complete dependency group can be ignored by 
+using the format `$GROUP`. Multiple dependencies can be ignored by passing the flag multiple times.
 
 ```bash
-# gradle useLatestVersions --ignore-dependency junit:junit --ignore-dependency com.google.guava:guava && gradle useLatestVersionsCheck --ignore-dependency junit:junit --ignore-dependency com.google.guava:guava
+# gradle useLatestVersions --ignore-dependency junit:junit --ignore-dependency com.google.guava && gradle useLatestVersionsCheck --ignore-dependency junit:junit --ignore-dependency com.google.guava
 ```
 
 ## Supported dependency formats

--- a/src/main/groovy/se/patrikerdes/Common.groovy
+++ b/src/main/groovy/se/patrikerdes/Common.groovy
@@ -6,6 +6,9 @@ import java.util.regex.Matcher
 
 @CompileStatic
 class Common {
+    public static final String WHITE_BLACKLIST_ERROR_MESSAGE = 'Using both, --update-dependency and ' +
+            '--ignore-dependency, is not allowed.'
+
     static List<DependencyUpdate> getOutDatedDependencies(Object dependencyUpdatesJson) {
         Object outdatedDependencies = dependencyUpdatesJson['outdated']['dependencies']
         List<DependencyUpdate> dependecyUpdates = []

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
@@ -93,7 +93,8 @@ class UseLatestVersionsCheckTask extends DefaultTask {
             println("useLatestVersions skipped updating $skippedCount ${deps(skippedCount)} " +
                     'not in --update-dependency:')
             for (dependencyLeftToUpdate in leftToUpdate) {
-                if (!updateWhitelist.contains(dependencyLeftToUpdate.groupAndName())) {
+                if (!updateWhitelist.contains(dependencyLeftToUpdate.groupAndName() &&
+                        !updateWhitelist.contains(dependencyLeftToUpdate.group))) {
                     println(' - ' + dependencyLeftToUpdate)
                 }
             }
@@ -102,7 +103,8 @@ class UseLatestVersionsCheckTask extends DefaultTask {
             println("useLatestVersions skipped updating $skippedCount ${deps(skippedCount)} " +
                     'in --ignore-dependency:')
             for (dependencyLeftToUpdate in leftToUpdate) {
-                if (updateBlacklist.contains(dependencyLeftToUpdate.groupAndName())) {
+                if (updateBlacklist.contains(dependencyLeftToUpdate.groupAndName()) ||
+                        updateBlacklist.contains(dependencyLeftToUpdate.group)) {
                     println(' - ' + dependencyLeftToUpdate)
                 }
             }
@@ -110,10 +112,16 @@ class UseLatestVersionsCheckTask extends DefaultTask {
     }
 
     private int getSkippedCount(List<DependencyUpdate> leftToUpdate) {
-        int skippedCount = updateWhitelist.empty ? 0 :
-                leftToUpdate.count { !updateWhitelist.contains(it.groupAndName()) } as int
+        int skippedCount = 0
+        if (!updateWhitelist.empty) {
+            skippedCount = leftToUpdate.count {
+                !updateWhitelist.contains(it.groupAndName()) && !updateWhitelist.contains(it.group)
+            } as int
+        }
         if (!updateBlacklist.empty) {
-            skippedCount = leftToUpdate.count { updateBlacklist.contains(it.groupAndName()) } as int
+            skippedCount = leftToUpdate.count {
+                updateBlacklist.contains(it.groupAndName()) || updateBlacklist.contains(it.group)
+            } as int
         }
         skippedCount
     }

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
@@ -1,6 +1,7 @@
 package se.patrikerdes
 
 import static se.patrikerdes.Common.getOutDatedDependencies
+import static se.patrikerdes.Common.WHITE_BLACKLIST_ERROR_MESSAGE
 import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
@@ -10,9 +11,13 @@ import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
 class UseLatestVersionsCheckTask extends DefaultTask {
-    @Option(option='update-dependency',
+    @Option(option = 'update-dependency',
             description = 'The same argument that was passed to useLatestVersions')
     List<String> updateWhitelist = Collections.emptyList()
+
+    @Option(option = 'ignore-dependency',
+            description = 'A blacklist of dependencies to update, in the format of group:name')
+    List<String> updateBlacklist = Collections.emptyList()
 
     UseLatestVersionsCheckTask() {
         description = 'Check if all available updates were successfully applied by the useLatestVersions task.'
@@ -21,6 +26,7 @@ class UseLatestVersionsCheckTask extends DefaultTask {
 
     @TaskAction
     void useLatestVersionsCheckTask() {
+        validateExclusiveWhiteOrBlacklist()
         File previousDependencyUpdatesReport =
                 new File(new File(project.buildDir, 'useLatestVersions'), 'latestDependencyUpdatesReport.json')
         File currentDependencyUpdatesReport =
@@ -36,8 +42,7 @@ class UseLatestVersionsCheckTask extends DefaultTask {
         List<DependencyUpdate> wasUpdateable = getOutDatedDependencies(previousDependencyUpdatesJson)
         List<DependencyUpdate> leftToUpdate = getOutDatedDependencies(currentDependencyUpdatesJson)
 
-        int skippedCount = updateWhitelist.empty ? 0 :
-                leftToUpdate.count { !updateWhitelist.contains(it.groupAndName()) } as int
+        int skippedCount = getSkippedCount(leftToUpdate)
         int failedCount = leftToUpdate.size() - skippedCount
         if (failedCount > 0) {
             println("useLatestVersions failed to update $failedCount ${deps(failedCount)} " +
@@ -71,13 +76,7 @@ class UseLatestVersionsCheckTask extends DefaultTask {
         }
 
         if (skippedCount > 0) {
-            println("useLatestVersions skipped updating $skippedCount ${deps(skippedCount)} " +
-                    'not in --dependency-update:')
-            for (dependencyLeftToUpdate in leftToUpdate) {
-                if (!updateWhitelist.contains(dependencyLeftToUpdate.groupAndName())) {
-                    println(' - ' + dependencyLeftToUpdate)
-                }
-            }
+            printSkippedDependenciesMessage(skippedCount, leftToUpdate)
         }
 
         if (updatedCount == 0 && failedCount == 0) {
@@ -86,6 +85,42 @@ class UseLatestVersionsCheckTask extends DefaultTask {
 
         if (failedCount > 0) {
             throw new GradleException('useLatestVersions failed')
+        }
+    }
+
+    private void printSkippedDependenciesMessage(int skippedCount, List<DependencyUpdate> leftToUpdate) {
+        if (!updateWhitelist.empty) {
+            println("useLatestVersions skipped updating $skippedCount ${deps(skippedCount)} " +
+                    'not in --update-dependency:')
+            for (dependencyLeftToUpdate in leftToUpdate) {
+                if (!updateWhitelist.contains(dependencyLeftToUpdate.groupAndName())) {
+                    println(' - ' + dependencyLeftToUpdate)
+                }
+            }
+        }
+        if (!updateBlacklist.empty) {
+            println("useLatestVersions skipped updating $skippedCount ${deps(skippedCount)} " +
+                    'in --ignore-dependency:')
+            for (dependencyLeftToUpdate in leftToUpdate) {
+                if (updateBlacklist.contains(dependencyLeftToUpdate.groupAndName())) {
+                    println(' - ' + dependencyLeftToUpdate)
+                }
+            }
+        }
+    }
+
+    private int getSkippedCount(List<DependencyUpdate> leftToUpdate) {
+        int skippedCount = updateWhitelist.empty ? 0 :
+                leftToUpdate.count { !updateWhitelist.contains(it.groupAndName()) } as int
+        if (!updateBlacklist.empty) {
+            skippedCount = leftToUpdate.count { updateBlacklist.contains(it.groupAndName()) } as int
+        }
+        skippedCount
+    }
+
+    private void validateExclusiveWhiteOrBlacklist() {
+        if (!updateWhitelist.empty && !updateBlacklist.empty) {
+            throw new GradleException(WHITE_BLACKLIST_ERROR_MESSAGE)
         }
     }
 

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -67,10 +67,14 @@ class UseLatestVersionsTask extends DefaultTask {
 
         List<DependencyUpdate> dependencyUpdates = getOutDatedDependencies(dependencyUpdatesJson)
         if (!updateWhitelist.empty) {
-            dependencyUpdates = dependencyUpdates.findAll { updateWhitelist.contains(it.groupAndName()) }
+            dependencyUpdates = dependencyUpdates.findAll {
+                updateWhitelist.contains(it.groupAndName()) || updateWhitelist.contains(it.group)
+            }
         }
         if (!updateBlacklist.empty) {
-            dependencyUpdates = dependencyUpdates.findAll { !updateBlacklist.contains(it.groupAndName()) }
+            dependencyUpdates = dependencyUpdates.findAll {
+                !updateBlacklist.contains(it.groupAndName()) && !updateBlacklist.contains(it.group)
+            }
         }
 
         List<DependencyUpdate> dependencyStables = getCurrentDependencies(dependencyUpdatesJson)

--- a/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
@@ -38,6 +38,31 @@ class BaseFunctionalTest extends Specification {
                 .build()
     }
 
+    BuildResult useLatestVersionsWithout(String update) {
+        useLatestVersionsWithout([update])
+    }
+
+    BuildResult useLatestVersionsWithout(List<String> updates) {
+        List<String> arguments = ['useLatestVersions']
+        updates.each { arguments << '--ignore-dependency' << it }
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
+    }
+
+    BuildResult useLatestVersionsWithBlackAndWhitelist() {
+        List<String> arguments = ['useLatestVersions']
+        arguments << '--update-dependency' << 'junit:junit'
+        arguments << '--ignore-dependency' << 'log4j:log4j'
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .buildAndFail()
+    }
+
     BuildResult useLatestVersions(String gradleVersion) {
         GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -83,6 +108,31 @@ class BaseFunctionalTest extends Specification {
                 .withArguments(arguments)
                 .withPluginClasspath()
                 .build()
+    }
+
+    BuildResult useLatestVersionsCheckWithout(String update) {
+        useLatestVersionsCheckWithout([update])
+    }
+
+    BuildResult useLatestVersionsCheckWithout(List<String> updates) {
+        List<String> arguments = ['useLatestVersionsCheck']
+        updates.each { arguments << '--ignore-dependency' << it }
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
+    }
+
+    BuildResult useLatestVersionsCheckWithBlackAndWhitelist() {
+        List<String> arguments = ['useLatestVersionsCheck']
+        arguments << '--update-dependency' << 'junit:junit'
+        arguments << '--ignore-dependency' << 'log4j:log4j'
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .buildAndFail()
     }
 
     BuildResult clean() {

--- a/src/test/groovy/se/patrikerdes/CheckFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/CheckFunctionalTest.groovy
@@ -2,6 +2,7 @@ package se.patrikerdes
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static se.patrikerdes.Common.WHITE_BLACKLIST_ERROR_MESSAGE
 
 import org.gradle.testkit.runner.BuildResult
 
@@ -244,8 +245,97 @@ class CheckFunctionalTest extends BaseFunctionalTest {
         String output = result.output.replaceAll('\r', '').replaceAll('\n', '#')
         output.contains('useLatestVersions successfully updated 1 dependency to the latest version:#' +
             " - log4j:log4j [1.2.16 -> $CurrentVersions.LOG4J]")
-        output.contains('useLatestVersions skipped updating 1 dependency not in --dependency-update:#' +
+        output.contains('useLatestVersions skipped updating 1 dependency not in --update-dependency:#' +
             " - junit:junit [3.0 -> $CurrentVersions.JUNIT]")
+    }
+
+    void "useLatestVersionsCheck notes skipped updates due to being in --ignore-dependency"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile "log4j:log4j:1.2.16"
+                testCompile "junit:junit:3.0"
+            }
+        """
+
+        when:
+        useLatestVersionsWithout('junit:junit')
+        BuildResult result = useLatestVersionsCheckWithout('junit:junit')
+
+        then:
+        result.task(':useLatestVersionsCheck').outcome == SUCCESS
+        String output = result.output.replaceAll('\r', '').replaceAll('\n', '#')
+        output.contains('useLatestVersions successfully updated 1 dependency to the latest version:#' +
+            " - log4j:log4j [1.2.16 -> $CurrentVersions.LOG4J]")
+        output.contains('useLatestVersions skipped updating 1 dependency in --ignore-dependency:#' +
+            " - junit:junit [3.0 -> $CurrentVersions.JUNIT]")
+    }
+
+    void "useLatestVersions fails if both --ignore-dependency and --update-dependency are set"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile "log4j:log4j:1.2.16"
+                testCompile "junit:junit:3.0"
+            }
+        """
+
+        when:
+        BuildResult result = useLatestVersionsWithBlackAndWhitelist()
+
+        then:
+        result.task(':useLatestVersions').outcome == FAILED
+        result.output.contains(WHITE_BLACKLIST_ERROR_MESSAGE)
+    }
+
+    void "useLatestVersionsCheck fails if both --ignore-dependency and --update-dependency are set"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile "log4j:log4j:1.2.16"
+                testCompile "junit:junit:3.0"
+            }
+        """
+
+        when:
+        BuildResult result = useLatestVersionsCheckWithBlackAndWhitelist()
+
+        then:
+        result.task(':useLatestVersionsCheck').outcome == FAILED
+        result.output.contains(WHITE_BLACKLIST_ERROR_MESSAGE)
     }
 
     void "useLatestVersionsCheck outputs a special message when there was nothing to update"() {

--- a/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
@@ -360,4 +360,33 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
         updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
     }
+
+    void "don't updates blacklisted dependencies with --ignore-dependency"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                testCompile "junit:junit:4.0:javadoc@jar"
+                compile "log4j:log4j:1.2.16"
+            }
+        """
+
+        when:
+        useLatestVersionsWithout('junit:junit')
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
+    }
 }

--- a/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
@@ -361,6 +361,35 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
     }
 
+    void "only updates whitelisted dependencies with --update-dependency as group"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                testCompile "junit:junit:4.0:javadoc@jar"
+                compile "log4j:log4j:1.2.16"
+            }
+        """
+
+        when:
+        useLatestVersionsOnly('log4j')
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
+    }
+
     void "don't updates blacklisted dependencies with --ignore-dependency"() {
         given:
         buildFile << """
@@ -387,6 +416,37 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
 
         then:
         updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
+    }
+
+    void "don't updates blacklisted dependencies with --ignore-dependency as group"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                testCompile "junit:junit:4.0:javadoc@jar"
+                testCompile "junit:junit-dep:4.9"
+                compile "log4j:log4j:1.2.16"
+            }
+        """
+
+        when:
+        useLatestVersionsWithout('junit')
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains('testCompile "junit:junit-dep:4.9"')
         updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
     }
 }


### PR DESCRIPTION
Some dependencies you don't want to upgrade, because there are known issues or incompatibilities. These dependencies you want to blacklist.

This PR allows to blacklist dependencies via command-line parameters.
It is pretty similar to and inspired by PR https://github.com/patrikerdes/gradle-use-latest-versions-plugin/pull/27 (Add flag to update only explicitly listed dependencies).