### PR TITLE
Add support to update root gradle.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ apply {
 
 ```
 
+### Multi-project usage
+In case you have a Multi-project build and you have some common dependency configuration in some common file in root project 
+(like *.gradle file), you should apply plugin to all projects. Easiest way to do this is with `allprojects` block like:
+```
+plugins {
+  id 'se.patrikerdes.use-latest-versions' version '0.2.13'
+  id 'com.github.ben-manes.versions' version '0.21.0'
+}
+
+allprojects {
+    apply plugin: 'se.patrikerdes.use-latest-versions'
+    apply plugin: 'com.github.ben-manes.versions'
+}
+```
+This is because `se.patrikerdes.use-latest-versions` plugin scans files for every project separately. 
+
+In case you handle dependencies per project separately this is not needed and you can apply plugin just to selected projects.
+
 ## Example
 
 Given this build.gradle file:
@@ -143,7 +161,22 @@ dependencies {
 ### useLatestVersions
 
 ```bash
-# gradle useLatestVersions
+gradle useLatestVersions
+
+# Configuration and default values:
+useLatestVersions {
+   # A whitelist of dependencies to update, in the format of group:name
+   # Equal to command line: --update-dependency=[values]
+   updateWhitelist = []
+   # A blacklist of dependencies to update, in the format of group:name
+   # Equal to command line: --ignore-dependency=[values]
+   updateBlacklist = []
+   # When enabled, root project gradle.properties will also be populated with 
+   # versions from subprojects in multi-project build
+   # Equal to command line: --update-root-properties
+   updateRootProperties = false
+}
+
 ```
 
 Updates module and plugin versions in all *.gradle files in the project root folder or any subfolder to the latest

--- a/src/main/groovy/se/patrikerdes/InternalAggregateRootTask.groovy
+++ b/src/main/groovy/se/patrikerdes/InternalAggregateRootTask.groovy
@@ -1,0 +1,69 @@
+package se.patrikerdes
+
+import static se.patrikerdes.UseLatestVersionsPlugin.USE_LATEST_VERSIONS
+
+import org.gradle.api.Project
+import groovy.json.JsonSlurper
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class InternalAggregateRootTask extends DefaultTask {
+
+    InternalAggregateRootTask() {
+        description = 'Internal task that aggregates versions of all projects to root. ' +
+                'Currently it updates just gradle.properties in root. Don\'t run it as separate task'
+    }
+
+    @TaskAction
+    void internalAggregateRootTask() {
+        List<String> versionVariablesFiles = project.gradle.taskGraph.allTasks
+                .findAll { it.name == USE_LATEST_VERSIONS }
+                .collectMany { getVersionVariablesFiles(it.project) }
+        List<String> dotGradleFileNames =
+                new FileNameFinder().getFileNames(project.projectDir.absolutePath, 'gradle.properties')
+
+        Map<String, String> gradleFileContents = dotGradleFileNames.collectEntries {
+            [(it): new File(it).getText('UTF-8')]
+        }
+        Map<String, String> versionVariables = readVersionVariables(versionVariablesFiles)
+        Common.updateVersionVariables(gradleFileContents, dotGradleFileNames, versionVariables)
+
+        // Write all files back
+        for (dotGradleFileName in dotGradleFileNames) {
+            new File(dotGradleFileName).setText(gradleFileContents[dotGradleFileName], 'UTF-8')
+        }
+
+        // Delete temp files in build folder
+        for (String versionVariablesFile in versionVariablesFiles) {
+            new File(versionVariablesFile).delete()
+        }
+    }
+
+    List<String> getVersionVariablesFiles(Project project) {
+        String buildDir = project.buildDir.absolutePath
+        new FileNameFinder().getFileNames(buildDir, 'useLatestVersions/version-variables.json')
+    }
+
+    Map<String, String> readVersionVariables(List<String> versionVariablesFiles) {
+        Map<String, String> versionVariables = [:]
+        List<String> problemVariables = []
+        for (String versionVariablesFile in versionVariablesFiles) {
+            Map<String, String> variables = new JsonSlurper().parseText(new File(versionVariablesFile).text)
+            variables.forEach { k, v ->
+                if (versionVariables.containsKey(k) && versionVariables.get(k) != v) {
+                    println("A problem was detected: the variable '$k' has different updated versions in different " +
+                            "projects.\nNew updated versions are: '${versionVariables.get(k)}' and '$v', " +
+                            "root gradle.properties value won't be be changed.")
+                    problemVariables.add(k)
+                } else {
+                    versionVariables.put(k, v)
+                }
+            }
+        }
+        for (problemVariable in problemVariables) {
+            versionVariables.remove(problemVariable)
+        }
+        versionVariables
+    }
+
+}

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsPlugin.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsPlugin.groovy
@@ -3,12 +3,43 @@ package se.patrikerdes
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.Plugin
+import org.gradle.api.Task
 
 @CompileStatic
 class UseLatestVersionsPlugin implements Plugin<Project> {
+
+    static final String DEPENDENCY_UPDATES = 'dependencyUpdates'
+    static final String USE_LATEST_VERSIONS = 'useLatestVersions'
+    static final String USE_LATEST_VERSIONS_CHECK = 'useLatestVersionsCheck'
+    static final String INTERNAL_ROOT_AGGREGATE = 'internalRootAggregate'
+
     void apply(Project project) {
         System.setProperty('outputFormatter', 'json,xml,plain')
-        project.task('useLatestVersions', type: UseLatestVersionsTask, dependsOn: 'dependencyUpdates')
-        project.task('useLatestVersionsCheck', type: UseLatestVersionsCheckTask, dependsOn: 'dependencyUpdates')
+        Task rootAggregate = setupRootAggregateTask(project)
+        setupUseLatestVersions(project, rootAggregate)
+        setupUseLatestVersionsCheck(project)
     }
+
+    Task setupRootAggregateTask(Project project) {
+        Set<Task> tasks = project.rootProject.getTasksByName(INTERNAL_ROOT_AGGREGATE, false)
+        if (tasks.isEmpty()) {
+            // This handles both cases: when UseLatestVersionsPlugin is applied
+            // to root project and subprojects or when it is applied only to subprojects
+            return project.rootProject.task(INTERNAL_ROOT_AGGREGATE, type: InternalAggregateRootTask)
+        }
+        tasks[0]
+    }
+
+    void setupUseLatestVersions(Project project, Task rootAggregate) {
+        Task useLatestVersions = project.task(USE_LATEST_VERSIONS, type: UseLatestVersionsTask)
+        useLatestVersions.dependsOn(DEPENDENCY_UPDATES)
+        useLatestVersions.finalizedBy(rootAggregate)
+        rootAggregate.mustRunAfter(useLatestVersions)
+    }
+
+    void setupUseLatestVersionsCheck(Project project) {
+        Task useLatestVersionCheck = project.task(USE_LATEST_VERSIONS_CHECK, type: UseLatestVersionsCheckTask)
+        useLatestVersionCheck.dependsOn(DEPENDENCY_UPDATES)
+    }
+
 }

--- a/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
@@ -63,6 +63,14 @@ class BaseFunctionalTest extends Specification {
                 .buildAndFail()
     }
 
+    BuildResult useLatestVersionsUpdatingRootProperties() {
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('useLatestVersions', '--update-root-properties')
+                .withPluginClasspath()
+                .build()
+    }
+
     BuildResult useLatestVersions(String gradleVersion) {
         GradleRunner.create()
                 .withProjectDir(testProjectDir.root)

--- a/src/test/groovy/se/patrikerdes/CurrentVersions.groovy
+++ b/src/test/groovy/se/patrikerdes/CurrentVersions.groovy
@@ -3,5 +3,6 @@ package se.patrikerdes
 class CurrentVersions {
     public static final String VERSIONS = '0.28.0'
     public static final String JUNIT = '4.13'
+    public static final String JUNIT_DEPS = '4.11'
     public static final String LOG4J = '1.2.17'
 }

--- a/src/test/groovy/se/patrikerdes/VariableUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/VariableUpdatesFunctionalTest.groovy
@@ -451,4 +451,278 @@ class VariableUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedGradlePropertiesFile.contains("junit_version = $CurrentVersions.JUNIT")
         updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
     }
+
+    void "will update variables in gradle properties when specified twice in build gradle"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                testCompile "log4j:log4j:\$log4j_version"
+                runtimeOnly "log4j:log4j:\$log4j_version"
+            }
+        """
+        File gradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        gradlePropertiesFile << '''
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+
+        when:
+        useLatestVersions()
+        String updatedGradlePropertiesFile = gradlePropertiesFile.getText('UTF-8')
+
+        then:
+        updatedGradlePropertiesFile.contains("junit_version = $CurrentVersions.JUNIT")
+        updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
+    }
+
+    void "will not update variables in root gradle properties in Multi-project without --update-root-properties"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            allprojects {
+                apply plugin: 'se.patrikerdes.use-latest-versions'
+                apply plugin: 'com.github.ben-manes.versions'
+                apply plugin: 'java'
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+        File rootGradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        rootGradlePropertiesFile << '''
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+        File rootGradleSettingsFile = testProjectDir.newFile('settings.gradle')
+        rootGradleSettingsFile << '''
+            include 'sub-project'
+        '''
+        File subProjectFolder = testProjectDir.newFolder('sub-project')
+        File subProjectBuildFile = new File(subProjectFolder, 'build.gradle')
+        subProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                compile "log4j:log4j:\$log4j_version"
+            }
+        '''
+
+        when:
+        useLatestVersions()
+
+        then:
+        String updatedGradlePropertiesFile = rootGradlePropertiesFile.getText('UTF-8')
+        updatedGradlePropertiesFile.contains('junit_version = 4.0')
+        updatedGradlePropertiesFile.contains('log4j_version=1.2.16')
+    }
+
+    void "will update variables in root gradle properties for Multi-project build"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            allprojects {
+                apply plugin: 'se.patrikerdes.use-latest-versions'
+                apply plugin: 'com.github.ben-manes.versions'
+                apply plugin: 'java'
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+        File rootGradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        rootGradlePropertiesFile << '''
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+        File rootGradleSettingsFile = testProjectDir.newFile('settings.gradle')
+        rootGradleSettingsFile << '''
+            include 'sub-project'
+        '''
+        File subProjectFolder = testProjectDir.newFolder('sub-project')
+        File subProjectBuildFile = new File(subProjectFolder, 'build.gradle')
+        subProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                compile "log4j:log4j:\$log4j_version"
+            }
+        '''
+
+        when:
+        useLatestVersionsUpdatingRootProperties()
+
+        then:
+        String updatedGradlePropertiesFile = rootGradlePropertiesFile.getText('UTF-8')
+        updatedGradlePropertiesFile.contains("junit_version = $CurrentVersions.JUNIT")
+        updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
+    }
+
+    void "will update variables in root gradle properties for Multi-project when plugin applied to subproject only"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions' apply false
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS' apply false
+            }
+
+            subprojects {
+                apply plugin: 'se.patrikerdes.use-latest-versions'
+                apply plugin: 'com.github.ben-manes.versions'
+                apply plugin: 'java'
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+        File rootGradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        rootGradlePropertiesFile << '''
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+        File rootGradleSettingsFile = testProjectDir.newFile('settings.gradle')
+        rootGradleSettingsFile << '''
+            include 'sub-project'
+        '''
+        File subProjectFolder = testProjectDir.newFolder('sub-project')
+        File subProjectBuildFile = new File(subProjectFolder, 'build.gradle')
+        subProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                compile "log4j:log4j:\$log4j_version"
+            }
+        '''
+
+        when:
+        useLatestVersionsUpdatingRootProperties()
+
+        then:
+        String updatedGradlePropertiesFile = rootGradlePropertiesFile.getText('UTF-8')
+        updatedGradlePropertiesFile.contains("junit_version = $CurrentVersions.JUNIT")
+        updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
+    }
+
+    void "will update variables in root gradle properties for Multi-project when present in multiple projects"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            allprojects {
+                apply plugin: 'se.patrikerdes.use-latest-versions'
+                apply plugin: 'com.github.ben-manes.versions'
+                apply plugin: 'java'
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+        File rootGradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        rootGradlePropertiesFile << '''
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+        File rootGradleSettingsFile = testProjectDir.newFile('settings.gradle')
+        rootGradleSettingsFile << '''
+            include 'first-sub-project'
+            include 'second-sub-project'
+        '''
+        File firstSubProjectFolder = testProjectDir.newFolder('first-sub-project')
+        File firstSubProjectBuildFile = new File(firstSubProjectFolder, 'build.gradle')
+        firstSubProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                compile "log4j:log4j:\$log4j_version"
+            }
+        '''
+        File secondSubProjectFolder = testProjectDir.newFolder('second-sub-project')
+        File secondSubProjectBuildFile = new File(secondSubProjectFolder, 'build.gradle')
+        secondSubProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                compile "log4j:log4j:\$log4j_version"
+            }
+        '''
+
+        when:
+        useLatestVersionsUpdatingRootProperties()
+
+        then:
+        String updatedGradlePropertiesFile = rootGradlePropertiesFile.getText('UTF-8')
+        updatedGradlePropertiesFile.contains("junit_version = $CurrentVersions.JUNIT")
+        updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
+    }
+
+    void "will not update variables in root gradle properties for Multi-project when not resolved to same version"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions' apply false
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS' apply false
+            }
+
+            allprojects {
+                apply plugin: 'se.patrikerdes.use-latest-versions'
+                apply plugin: 'com.github.ben-manes.versions'
+                apply plugin: 'java'
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+        File rootGradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        rootGradlePropertiesFile << '''
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+        File rootGradleSettingsFile = testProjectDir.newFile('settings.gradle')
+        rootGradleSettingsFile << '''
+            include 'first-sub-project'
+            include 'second-sub-project'
+        '''
+        File firstSubProjectFolder = testProjectDir.newFolder('first-sub-project')
+        File firstSubProjectBuildFile = new File(firstSubProjectFolder, 'build.gradle')
+        firstSubProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+            }
+        '''
+        File secondSubProjectFolder = testProjectDir.newFolder('second-sub-project')
+        File secondSubProjectBuildFile = new File(secondSubProjectFolder, 'build.gradle')
+        secondSubProjectBuildFile << '''
+            dependencies {
+                testCompile "junit:junit-dep:\$junit_version"
+            }
+        '''
+
+        when:
+        BuildResult result = useLatestVersionsUpdatingRootProperties()
+
+        then:
+        String updatedGradlePropertiesFile = rootGradlePropertiesFile.getText('UTF-8')
+        updatedGradlePropertiesFile.contains('junit_version = 4.0')
+        result.output.contains("A problem was detected: the variable 'junit_version' has different updated versions " +
+                "in different projects.\nNew updated versions are: '$CurrentVersions.JUNIT' and " +
+                "'$CurrentVersions.JUNIT_DEPS', root gradle.properties value won't be be changed.")
+    }
+
 }


### PR DESCRIPTION
This fixes: #28.

Basic idea:
- every`useLatestVersions` task writes variables to `build/useLatestVersions/version-variables.json`
- we have one "aggregation" task `internalRootAggregate` that at the end reads all version-variables.json, merges them if possible (there is check that versions match) and writes to gradle.properties 
- at the end `internalRootAggregate` also deletes all `version-variables.json` files
- all `useLatestVersions` tasks are finalized by `internalRootAggregate` task and `internalRootAggregate` task must run after all `useLatestVersions` tasks

By default this behavior is disabled, but can be enabled with --updateRootProperties or as: 
```
useLatestVersions {
   updateRootProperties=true  
}
```

**Note**: when updateRootProperties=false, subprojects won't make version-variables.json file, but internalRootAggregate task will be run anyway, it just won't be able to read variables of subprojects.

I also included one small change, now variables that are defined multiple times in *.gradle file are also matched (change in `Common.getVariablesFromMatches`). Previously if you had two same version variables in *.gradle file it was not updated (also no problem was printed).
