### PR TITLE
Add option to specify version files

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ useLatestVersions {
    # versions from subprojects in multi-project build
    # Equal to command line: --update-root-properties
    updateRootProperties = false
+   # By default plugin tries to find all relevant gradle files (e.g. *.gradle, gradle.properties etc). 
+   # This can be slow in some cases when project has a lot of gradle files. For example when using conventions 
+   # in buildSrc. With this option you can specify what files should plugin search and check. Plugin will ignore
+   # files that don't exist. Empty list means use default strategy. File paths are relative to project dir.
+   #
+   # Example:
+   # versionFiles = ["gradle.build", "gradle.properties"]
+   # Will check just $projectDir/gradle.build and $projectDir/gradle.properties
+   #
+   # Note:
+   # You always have to specify file that has dependencies in some common dependency format with artifact coordinates,
+   # e.g. compileOnly "group:module:version" or compileOnly("group:module:version") or val dependency = "group:module:version" etc. 
+   # For example if you set just versionFiles = ["gradle.properties"] this won't work, since plugin 
+   # won't be able to correlate variable with artifact coordinates.
+   #
+   # Equal to command line: --version-files=[values]
+   versionFiles = []
    # List of root project files to update when updateRootProperties is enabled.
    # `build.gradle` is not an acceptable entry here as it breaks other expected
    # functionality. Version variables in `build.gradle` need to be moved into

--- a/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
@@ -79,6 +79,18 @@ class BaseFunctionalTest extends Specification {
                 .buildAndFail()
     }
 
+    BuildResult useLatestVersionsWithVersionFiles(String... versionFiles) {
+        List<String> arguments = ['useLatestVersions']
+        for (versionFile in versionFiles) {
+            arguments << '--version-files' << versionFile
+        }
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
+    }
+
     BuildResult useLatestVersionsUpdatingRootPropertiesWithRootList(String... rootVersionsList) {
         List<String> arguments = ['useLatestVersions', '--update-root-properties']
         for (versionFile in rootVersionsList) {

--- a/src/test/groovy/se/patrikerdes/CurrentVersions.groovy
+++ b/src/test/groovy/se/patrikerdes/CurrentVersions.groovy
@@ -1,8 +1,8 @@
 package se.patrikerdes
 
 class CurrentVersions {
-    public static final String VERSIONS = '0.33.0'
-    public static final String JUNIT = '4.13'
+    public static final String VERSIONS = '0.38.0'
+    public static final String JUNIT = '4.13.2'
     public static final String JUNIT_DEPS = '4.11'
     public static final String LOG4J = '1.2.17'
 }


### PR DESCRIPTION
This fixes https://github.com/patrikerdes/gradle-use-latest-versions-plugin/issues/48 as proposed in the issue.

Additionally it excludes `buildSrc/build/**/*.kt` files when matching files  with `buildSrc/**/*.kt` in UseLatestVersionsTask.groovy.