### PR TITLE
Fix for #51

### DIFF
--- a/src/main/groovy/se/patrikerdes/Common.groovy
+++ b/src/main/groovy/se/patrikerdes/Common.groovy
@@ -145,11 +145,11 @@ class Common {
     }
 
     static String variableDefinitionMatchString(String variable) {
-        '(' + Pattern.quote(variable) + "[ \t]*=[ \t]*[\"'])(.*)([\"'])"
+        '(\\b' + Pattern.quote(variable) + "[ \t]*=[ \t]*[\"'])(.*)([\"'])"
     }
 
     static String gradlePropertiesVariableDefinitionMatchString(String variable) {
-        '(' + Pattern.quote(variable) + '[ \t]*=[ \t]*)(.*)([ \t]*)'
+        '(\\b' + Pattern.quote(variable) + '[ \t]*=[ \t]*)(.*)([ \t]*)'
     }
 
     static String newVariableDefinitionString(String newVersion) {

--- a/src/test/groovy/se/patrikerdes/VariableUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/VariableUpdatesFunctionalTest.groovy
@@ -452,6 +452,42 @@ class VariableUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
     }
 
+    void "a variable assigned in gradle properties will be updated, without touching those it's a suffix of"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                testCompile "junit:junit:\$junit_version"
+                compile "log4j:log4j:\$log4j_version"
+            }
+        """
+        File gradlePropertiesFile = testProjectDir.newFile('gradle.properties')
+        gradlePropertiesFile << '''
+            prefix_junit_version = 4.0
+            junit_version = 4.0
+            log4j_version=1.2.16
+        '''
+
+        when:
+        useLatestVersions()
+        String updatedGradlePropertiesFile = gradlePropertiesFile.getText('UTF-8')
+
+        then:
+        updatedGradlePropertiesFile.contains('prefix_junit_version = 4.0')
+        updatedGradlePropertiesFile.contains("junit_version = $CurrentVersions.JUNIT")
+        updatedGradlePropertiesFile.contains("log4j_version=$CurrentVersions.LOG4J")
+    }
+
     void "will update variables in gradle properties when specified twice in build gradle"() {
         given:
         buildFile << """


### PR DESCRIPTION
Adds a test that fails with the old behavior, and also fixes the behavior.

Uses `\b`, the (zero width) "word boundary" matcher to make sure it's getting the entire variable name.