### PR TITLE
Recognise Kotlin plugin format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,13 @@ repositories {
 }
 
 dependencies {
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
+    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude(module: 'groovy-all')
     }
 }
 
 group = 'se.patrikerdes'
-version = '0.2.16'
+version = '0.2.17'
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
+++ b/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy
@@ -39,6 +39,9 @@ class DependencyUpdate {
     String oldPluginVersionMatchString() {
         "(id[ \\t\\(]+[\"']" + this.groupQ + "[\"'][ \\t\\)]+version[ \\t]+[\"'])" + this.oldVersionQ + "([\"'])"
     }
+    String oldKotlinPluginVersionMatchString() {
+        '(kotlin\\(\"' + this.group.split('\\.').last() + '\"\\)\\s+version\\s+\")' + this.oldVersionQ + '(\")'
+    }
     String oldModuleVersionKotlinUnnamedParametersMatchString() {
         '((?:testRuntimeOnly|implementation|annotationProcessor|api|apiDependenciesMetadata|apiElements|compile|' +
                 'compileClasspath|compileOnly|compileOnlyDependenciesMetadata|implementation|' +

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -168,6 +168,10 @@ class UseLatestVersionsTask extends DefaultTask {
                 gradleFileContents[dotGradleFileName] =
                         gradleFileContents[dotGradleFileName].replaceAll(
                                 update.oldPluginVersionMatchString(), update.newVersionString())
+
+                gradleFileContents[dotGradleFileName] =
+                        gradleFileContents[dotGradleFileName].replaceAll(
+                                update.oldKotlinPluginVersionMatchString(), update.newVersionString())
             }
         }
     }

--- a/src/test/groovy/se/patrikerdes/kotlindsl/KotlinPluginUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/kotlindsl/KotlinPluginUpdatesFunctionalTest.groovy
@@ -23,4 +23,27 @@ class KotlinPluginUpdatesFunctionalTest extends KotlinBaseFunctionalTest {
         updatedBuildFile.contains('id("org.gradle.hello-world") version "0.2"')
     }
 
+    void "an outdated Kotlin plugin can be updated"() {
+        given:
+        buildFile << """
+            plugins {
+                application
+                java
+                id("se.patrikerdes.use-latest-versions")
+                id("com.github.ben-manes.versions") version "$CurrentVersions.VERSIONS"
+                kotlin("jvm") version "1.4.32"
+            }
+        """
+
+        when:
+        useLatestVersions()
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.eachMatch('kotlin\\(\"jvm\"\\) version \"(.+)\"') { version ->
+            // saves us having to hardcode a version number which will need updating in the future
+            version.size() == 2
+            version[1].split('\\.')[1].toInteger() > 4
+        }
+    }
 }


### PR DESCRIPTION
In the kotlin gradle dsl, there is a convenience method for specifying kotlin dependencies:
```gradle
plugins {
    kotlin("jvm") version "1.5.10"
    // id("org.jetbrains.kotlin.jvm") version "1.5.10"
}
```

The latest-versions plugin recognises this format, but use-latest-versions does not yet change the version. This change handles it.