### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Include in your `build.gradle`
 ```groovy
 plugins {
   id 'se.patrikerdes.use-latest-versions' version '0.2.18'
-  id 'com.github.ben-manes.versions' version '0.21.0'
+  id 'com.github.ben-manes.versions' version '0.41.0'
 }
 ```
 


### PR DESCRIPTION
```
./gradlew useLatestVersions
> Task :app:dependencyUpdates FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':app:dependencyUpdates' (type 'DependencyUpdatesTask').
  - In plugin 'com.github.ben-manes.versions' type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'checkForGradleUpdate' has redundant getters: 'getCheckForGradleUpdate()' and 'isCheckForGradleUpdate()'.

    Reason: Boolean property 'checkForGradleUpdate' has both an `is` and a `get` getter.

    Possible solutions:
      1. Remove one of the getters.
      2. Annotate one of the getters with @Internal.

    Please refer to https://docs.gradle.org/7.3.3/userguide/validation_problems.html#redundant_getters for more details about this problem.
  - In plugin 'com.github.ben-manes.versions' type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'outputFormatter' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.3.3/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - In plugin 'com.github.ben-manes.versions' type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'resolutionStrategy' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.3.3/userguide/validation_problems.html#missing_annotation for more details about this problem.

```