### PR TITLE
Addition of --no-ignore-dependencies flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ useLatestVersions {
    updateWhitelist = []
    # A blacklist of dependencies to update, in the format of group:name
    # Equal to command line: --ignore-dependency=[values]
+   # Can be overridden to be an empty list with the command line: --no-ignore-dependencies which takes precedence over any --ignore-dependency=[value] options
    updateBlacklist = []
    # When enabled, root project gradle.properties will also be populated with 
    # versions from subprojects in multi-project build
@@ -234,9 +235,22 @@ using the format `$GROUP`. Multiple dependencies can be updated by passing the f
 If your Gradle version is 4.6 or higher, you can pass the `--ignore-dependency` flag to `useLatestVersions` and
 `useLatestVersionsCheck` with a value in the format `$GROUP:$NAME`. A complete dependency group can be ignored by 
 using the format `$GROUP`. Multiple dependencies can be ignored by passing the flag multiple times.
+Passing the flag `--no-ignore-dependencies` overwrites any `--ignore-dependency` values passed.
 
 ```bash
 # gradle useLatestVersions --ignore-dependency junit:junit --ignore-dependency com.google.guava && gradle useLatestVersionsCheck --ignore-dependency junit:junit --ignore-dependency com.google.guava
+```
+
+## Ignore all blacklisted dependency updates
+The `--no-ignore-dependencies` flag overrides any `--ignore-dependencies` flags which have been set.
+This is only needed where a blacklist is specified in a projects build file and you want to update only a specific version with `--update-dependency` due to the blacklist in the build file being automatically pulled in. 
+
+```bash
+# gradle useLatestVersions --update-dependency junit:junit --ignore-dependency com.google.guava --no-ignore-dependencies
+```
+is the equivalent of 
+```bash
+# gradle useLatestVersions --update-dependency junit:junit
 ```
 
 ## Supported dependency formats

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsCheckTask.groovy
@@ -23,6 +23,12 @@ class UseLatestVersionsCheckTask extends DefaultTask {
             description = 'A blacklist of dependencies to update, in the format of group:name')
     List<String> updateBlacklist = Collections.emptyList()
 
+    @Option(option='no-ignore-dependencies',
+            description = 'Forces the ignore-dependencies collection to be empty')
+    void setNoBlacklist() {
+        updateBlacklist = Collections.emptyList()
+    }
+
     UseLatestVersionsCheckTask() {
         description = 'Check if all available updates were successfully applied by the useLatestVersions task.'
         group = 'Help'

--- a/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
+++ b/src/main/groovy/se/patrikerdes/UseLatestVersionsTask.groovy
@@ -32,6 +32,12 @@ class UseLatestVersionsTask extends DefaultTask {
             description = 'A blacklist of dependencies to update, in the format of group:name')
     List<String> updateBlacklist = Collections.emptyList()
 
+    @Option(option='no-ignore-dependencies',
+            description = 'Forces the ignore-dependencies collection to be empty')
+    void setNoBlacklist() {
+        updateBlacklist = Collections.emptyList()
+    }
+
     @Input
     @Option(option='update-root-properties',
             description = 'Update root project gradle.properties with subprojects versions in multi-project build')

--- a/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/BaseFunctionalTest.groovy
@@ -120,6 +120,29 @@ class BaseFunctionalTest extends Specification {
                 .buildAndFail()
     }
 
+    BuildResult useLatestVersionsWithWhitelistAndNoIgnoreDependencies() {
+        List<String> arguments = ['useLatestVersions']
+        arguments << '--update-dependency' << 'log4j:log4j'
+        arguments << '--no-ignore-dependencies'
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
+    }
+
+    BuildResult useLatestVersionsWithBlackAndWhitelistAndNoIgnoreDependencies() {
+        List<String> arguments = ['useLatestVersions']
+        arguments << '--update-dependency' << 'log4j:log4j'
+        arguments << '--ignore-dependency' << 'junit:junit'
+        arguments << '--no-ignore-dependencies'
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
+    }
+
     BuildResult useLatestVersionsCheck() {
         GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -173,6 +196,18 @@ class BaseFunctionalTest extends Specification {
                 .withArguments(arguments)
                 .withPluginClasspath()
                 .buildAndFail()
+    }
+
+    BuildResult useLatestVersionsCheckWithBlackAndWhitelistAndNoIgnoreDependencies() {
+        List<String> arguments = ['useLatestVersionsCheck']
+        arguments << '--update-dependency' << 'log4j:log4j'
+        arguments << '--ignore-dependency' << 'junit:junit'
+        arguments << '--no-ignore-dependencies'
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .build()
     }
 
     BuildResult clean() {

--- a/src/test/groovy/se/patrikerdes/CheckFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/CheckFunctionalTest.groovy
@@ -472,6 +472,35 @@ class CheckFunctionalTest extends BaseFunctionalTest {
         result.output.contains(WHITE_BLACKLIST_ERROR_MESSAGE)
     }
 
+    void "useLatestVersionsCheck doesn't fail on --ignore-dependency --update-dependency --no-ignore-dependencies"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile "log4j:log4j:1.2.16"
+                testCompile "junit:junit:3.0"
+            }
+        """
+
+        when:
+        useLatestVersionsWithBlackAndWhitelistAndNoIgnoreDependencies()
+        BuildResult result = useLatestVersionsCheckWithBlackAndWhitelistAndNoIgnoreDependencies()
+
+        then:
+        result.task(':useLatestVersionsCheck').outcome == SUCCESS
+        !result.output.contains(WHITE_BLACKLIST_ERROR_MESSAGE)
+    }
+
     void "useLatestVersionsCheck outputs a special message when there was nothing to update"() {
         given:
         buildFile << """

--- a/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
+++ b/src/test/groovy/se/patrikerdes/ModuleUpdatesFunctionalTest.groovy
@@ -390,7 +390,7 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
     }
 
-    void "don't updates blacklisted dependencies with --ignore-dependency"() {
+    void "don't update blacklisted dependencies with --ignore-dependency"() {
         given:
         buildFile << """
             plugins {
@@ -419,7 +419,7 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
         updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
     }
 
-    void "don't updates blacklisted dependencies with --ignore-dependency as group"() {
+    void "don't update blacklisted dependencies with --ignore-dependency as group"() {
         given:
         buildFile << """
             plugins {
@@ -442,6 +442,68 @@ class ModuleUpdatesFunctionalTest extends BaseFunctionalTest {
 
         when:
         useLatestVersionsWithout('junit')
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains('testCompile "junit:junit-dep:4.9"')
+        updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
+    }
+
+    void "only updates whitelist with --update-dependency when --no-ignore-dependencies is also passed"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                testCompile "junit:junit:4.0:javadoc@jar"
+                testCompile "junit:junit-dep:4.9"
+                compile "log4j:log4j:1.2.16"
+            }
+        """
+
+        when:
+        useLatestVersionsWithWhitelistAndNoIgnoreDependencies()
+        String updatedBuildFile = buildFile.getText('UTF-8')
+
+        then:
+        updatedBuildFile.contains('testCompile \"junit:junit:4.0:javadoc@jar\"')
+        updatedBuildFile.contains('testCompile "junit:junit-dep:4.9"')
+        updatedBuildFile.contains("compile \"log4j:log4j:$CurrentVersions.LOG4J\"")
+    }
+
+    void "ignores --ignore-blacklist entries when --no-ignore-dependencies is passed"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'se.patrikerdes.use-latest-versions'
+                id 'com.github.ben-manes.versions' version '$CurrentVersions.VERSIONS'
+            }
+
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                testCompile "junit:junit:4.0:javadoc@jar"
+                testCompile "junit:junit-dep:4.9"
+                compile "log4j:log4j:1.2.16"
+            }
+        """
+
+        when:
+        useLatestVersionsWithBlackAndWhitelistAndNoIgnoreDependencies()
         String updatedBuildFile = buildFile.getText('UTF-8')
 
         then:


### PR DESCRIPTION
It is not currently possible to run with both the `--update-dependency` and `--ignore-dependency` flags set.

This poses a problem when you use a plugin to manage pinned versions of dependencies across a number of projects.
For example, the recent Spring Boot 3 release - a lot of dependencies are moving their latest versions to be compatible with this SB release. However there are a lot of breaking changes associated with that release so if you aren't ready to move to SB3 currently you need to maintain a list of blacklisted dependencies.
As a result, over a large real estate you need to pin these versions in a common place - a plugin.

When you want to upgrade your dependencies you want this plugin to be updated first, and then once that is updated, update everything else (otherwise if you updated everything at the same time you could pull in a SB3 version of a dependency which your now updated plugin specifically said to ignore).

Where this is problematic is if you specify a blacklist of dependencies in (say) your project's build.gradle such as 
`useLatestVersions {
    updateBlacklist = [
        'foo.bar'
    ]
}`
this is translated into a `--ignore-dependency` flag when `useLatestVersions` runs.

So if you wanted to update just your `com.my-plugin` plugin which manages your pinned dependencies, you would run a `./gradlew useLatestVersions --update-dependency com.my-plugin` command but as you have blacklisted dependencies in your build file, that command becomes `./gradlew --update-dependency com.my-plugin --ignore-dependency foo.bar` which fails as you can't specify both ignore and update flags at the same time.

This commit introduces a `--no-ignore-dependencies` flag which supersedes the `--ignore-dependency` flag forcing it to be an empty collection regardless of what is set.

Thus you are able to run two commands successfully:
1. `./gradlew useLatestVersions --update-dependency com.my-plugin --no-ignore-dependencies` which will update just the plugin which manages your dependencies and ignore any blacklisted dependencies set
2. `./gradlew useLatestVersions --ignore-dependency com.my-plugin` which will update everything else now your plugin has been updated (note that due to the blacklist specified in the build.gradle, this command would actually be `./gradlew useLatestVersions --ignore-dependency com.my-plugin --ignore-dependency foo.bar`.